### PR TITLE
Fix: Honor intEncoding: 'variant' for float f16 type

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,10 +70,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/incapdns/bincode-ts.git"
+    "url": "git+https://github.com/4t145/bincode-ts.git"
   },
   "bugs": {
-    "url": "https://github.com/incapdns/bincode-ts/issues"
+    "url": "https://github.com/4t145/bincode-ts/issues"
   },
-  "homepage": "https://github.com/incapdns/bincode-ts#readme"
+  "homepage": "https://github.com/4t145/bincode-ts#readme"
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "type": "module",
   "files": [
     "dist",
+    "tsconfig.json",
     "README.md",
     "LICENSE"
   ],

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "type": "module",
   "files": [
     "dist",
+    "src",
     "tsconfig.json",
     "README.md",
     "LICENSE"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "examples:enums": "ts-node examples/enums.ts",
     "examples:complex": "ts-node examples/complex-structures.ts",
     "examples:custom": "ts-node examples/custom-types.ts",
-    "prepublishOnly": "npm run build && npm test"
+    "prepublishOnly": "npm run build && npm test",
+    "prepare": "npm run build"
   },
   "keywords": [
     "typescript",

--- a/package.json
+++ b/package.json
@@ -6,13 +6,6 @@
   "module": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",
   "type": "module",
-  "exports": {
-    ".": {
-      "types": "./dist/types/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
-    }
-  },
   "files": [
     "dist",
     "README.md",
@@ -77,10 +70,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/4t145/bincode-ts.git"
+    "url": "git+https://github.com/incapdns/bincode-ts.git"
   },
   "bugs": {
-    "url": "https://github.com/4t145/bincode-ts/issues"
+    "url": "https://github.com/incapdns/bincode-ts/issues"
   },
-  "homepage": "https://github.com/4t145/bincode-ts#readme"
+  "homepage": "https://github.com/incapdns/bincode-ts#readme"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -465,9 +465,9 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, len = buffer
                 for (let index = 0; index < byteLength; index += 1) {
                     const {
                         value: element,
-                        offset: elementOffset
+                        offset: newOffset
                     } = decode<unknown>(elementDefinition, buffer, offset, len, config);
-                    offset += elementOffset
+                    offset = newOffset
                     collection.push(element)
                 }
                 value = collection as Value<T>
@@ -480,9 +480,9 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, len = buffer
                 for (const elementDefinition of tupleDefinition) {
                     const {
                         value: element,
-                        offset: elementOffset
+                        offset: newOffset
                     } = decode<unknown>(elementDefinition, buffer, offset, len, config);
-                    offset += elementOffset
+                    offset = newOffset
                     tupleValue.push(element)
                 }
                 value = tupleValue as Value<T>
@@ -496,9 +496,9 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, len = buffer
                 for (let index = 0; index < arrayDefinition.size; index += 1) {
                     const {
                         value: element,
-                        offset: elementOffset
+                        offset: newOffset
                     } = decode<unknown>(elementDefinition, buffer, offset, len, config);
-                    offset += elementOffset
+                    offset = newOffset
                     tupleValue.push(element)
                 }
                 value = tupleValue as Value<T>
@@ -513,10 +513,10 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, len = buffer
                         const type = structDefinition[field];
                         const {
                             value: fieldValue,
-                            offset: fieldOffset
+                            offset: newOffset
                         } = decode<unknown>(type, buffer, offset, len, config);
                         decodedObject[field] = fieldValue;
-                        offset += fieldOffset;
+                        offset = newOffset;
                     }
                 }
                 value = decodedObject as Value<T>
@@ -554,8 +554,8 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, len = buffer
                 }
                 const [variantType, variant] = indexedDefinition[variantIndex];
                 if (variantType !== null) {
-                    const { value: variantValue, offset: variantOffset } = decode<unknown>(variantType, buffer, offset, len, config);
-                    offset += variantOffset;
+                    const { value: variantValue, offset: newOffset } = decode<unknown>(variantType, buffer, offset, len, config);
+                    offset = newOffset;
                     value = EnumVariantValue(variant, variantValue) as Value<T>
                 } else {
                     value = EnumVariantValue(variant) as Value<T>

--- a/src/index.ts
+++ b/src/index.ts
@@ -325,16 +325,16 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, len = buffer
         if (flag <= U8_MAX) {
             zigzagInt = flag;
         } else if (flag === U16_FLAG) {
-            zigzagInt = view.getUint16(0, littleEndian);
+            zigzagInt = view.getUint16(1, littleEndian);
             size += 2;
         } else if (flag === U32_FLAG) {
-            zigzagInt = view.getUint32(0, littleEndian);
+            zigzagInt = view.getUint32(1, littleEndian);
             size += 4;
         } else if (flag === U64_FLAG) {
-            zigzagInt = view.getBigUint64(0, littleEndian);
+            zigzagInt = view.getBigUint64(1, littleEndian);
             size += 8;
         } else if (flag === U128_FLAG) {
-            zigzagInt = getU128(view, 0, littleEndian);
+            zigzagInt = getU128(view, 1, littleEndian);
             size += 16;
         } else {
             throw new BincodeError('BigintOutOfRange', `Invalid int encoding flag: ${flag}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export type CustomType<Value, TypeName extends string> = {
     [TYPE_KIND]: 'custom',
     type: TypeName,
     encode(buffer: ArrayBuffer, value: Value, offset: number, config: BincodeConfig): number,
-    decode(buffer: ArrayBuffer, offset: number, config: BincodeConfig): {
+    decode(bufferLike: Uint8Array, offset: number, config: BincodeConfig): {
         value: Value,
         offset: number
     }
@@ -305,14 +305,14 @@ const U128_FLAG = 254;
 const U128_MIN = -0x8000_0000_0000_0000_0000_0000_0000_0000n;
 const U128_MAX = 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffffn;
 export const array = <T, N extends number>(...element: T[] & { readonly length: N }): T[] & { readonly length: N } => element
-export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, config: BincodeConfig = BincodeConfig.STANDARD): {
+export const decode = <T>(type: T, bufferLike: Uint8Array, offset = 0, config: BincodeConfig = BincodeConfig.STANDARD): {
     value: Value<T>
     offset: number
 } => {
     if (config.limit !== undefined && offset >= config.limit) {
         throw new BincodeError('OverflowLimit', `Buffer overflow at offset ${offset}, limit is ${config.limit}`);
     }
-    let view = new DataView(buffer);
+    let view = new DataView(bufferLike.buffer, bufferLike.byteOffset, bufferLike.byteLength);
     const littleEndian = config.endian === 'little';
     const isVariantIntEncoding = config.intEncoding === 'variant';
     function decodeVariantInt(offset: number, view: DataView, type: IntType): {
@@ -445,7 +445,7 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, config: Binc
                     offset += 8;
                 }
                 const decoder = new TextDecoder();
-                value = decoder.decode(new Uint8Array(buffer, offset, Number(byteLength))) as Value<T>
+                value = decoder.decode(new Uint8Array(bufferLike.buffer, bufferLike.byteOffset + offset, Number(byteLength))) as Value<T>
                 offset += byteLength;
             }
             break
@@ -466,7 +466,7 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, config: Binc
                     const {
                         value: element,
                         offset: elementOffset
-                    } = decode<unknown>(elementDefinition, buffer, offset, config);
+                    } = decode<unknown>(elementDefinition, bufferLike, offset, config);
                     offset = elementOffset
                     collection.push(element)
                 }
@@ -481,7 +481,7 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, config: Binc
                     const {
                         value: element,
                         offset: elementOffset
-                    } = decode<unknown>(elementDefinition, buffer, offset, config);
+                    } = decode<unknown>(elementDefinition, bufferLike, offset, config);
                     offset = elementOffset
                     tupleValue.push(element)
                 }
@@ -497,7 +497,7 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, config: Binc
                     const {
                         value: element,
                         offset: elementOffset
-                    } = decode<unknown>(elementDefinition, buffer, offset, config);
+                    } = decode<unknown>(elementDefinition, bufferLike, offset, config);
                     offset = elementOffset
                     tupleValue.push(element)
                 }
@@ -514,7 +514,7 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, config: Binc
                         const {
                             value: fieldValue,
                             offset: fieldOffset
-                        } = decode<unknown>(type, buffer, offset, config);
+                        } = decode<unknown>(type, bufferLike, offset, config);
                         decodedObject[field] = fieldValue;
                         offset = fieldOffset;
                     }
@@ -554,7 +554,7 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, config: Binc
                 }
                 const [variantType, variant] = indexedDefinition[variantIndex];
                 if (variantType !== null) {
-                    const { value: variantValue, offset: variantOffset } = decode<unknown>(variantType, buffer, offset, config);
+                    const { value: variantValue, offset: variantOffset } = decode<unknown>(variantType, bufferLike, offset, config);
                     offset = variantOffset;
                     value = EnumVariantValue(variant, variantValue) as Value<T>
                 } else {
@@ -573,7 +573,7 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, config: Binc
                         offset
                     }
                 } else if (variantFlag === 1) {
-                    return decode<unknown>(optionDefinition.optionType, buffer, offset, config) as {
+                    return decode<unknown>(optionDefinition.optionType, bufferLike, offset, config) as {
                         value: Value<T>
                         offset: number
                     }
@@ -584,7 +584,7 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, config: Binc
         case "custom":
             {
                 const customType = type as CustomType<unknown, string>;
-                const { value: customValue, offset: customOffset } = customType.decode(buffer, offset, config);
+                const { value: customValue, offset: customOffset } = customType.decode(bufferLike, offset, config);
                 value = customValue as Value<T>;
                 offset = customOffset;
             }
@@ -847,7 +847,7 @@ export abstract class CustomTypeClass<V, S extends string> implements CustomType
     readonly abstract type: S;
 
     abstract encode(buffer: ArrayBuffer, value: V, offset: number, config: BincodeConfig): number;
-    abstract decode(buffer: ArrayBuffer, offset: number, config: BincodeConfig): { value: V, offset: number };
+    abstract decode(bufferLike: Uint8Array, offset: number, config: BincodeConfig): { value: V, offset: number };
 }
 
 // test

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { getI128, getU128, setI128, setU128 } from "./utils";
 
 type IntBitSize = 8 | 16 | 32 | 64 | 128
-type FloatBitSize = 32 | 64
+type FloatBitSize = 16 | 32 | 64
 
 export class BincodeError extends Error {
     bincodeErrorKind: 'Unimplemented' | 'OverflowLimit' | 'InvalidLength' | 'InvalidVariant' | 'InvalidOptionVariant' | 'InvalidType' | 'BigintOutOfRange';
@@ -75,8 +75,8 @@ export type i64 = TypeKindMarker<'i64'>;
 export const i64: i64 = TypeKindMarker('i64');
 export type i128 = TypeKindMarker<'i128'>;
 export const i128: i128 = TypeKindMarker('i128');
-// export type f16 = TypeKindMarker<'f16'>;
-// export const f16: f16 = TypeKindMarker('f16');
+export type f16 = TypeKindMarker<'f16'>;
+export const f16: f16 = TypeKindMarker('f16');
 export type f32 = TypeKindMarker<'f32'>;
 export const f32: f32 = TypeKindMarker('f32');
 export type f64 = TypeKindMarker<'f64'>;
@@ -264,7 +264,7 @@ export const $ = EnumVariantValue;
 
 export type Value<T> =
     T extends Type ?
-    T extends TypeKindMarker<`${'u' | 'i'}${8 | 16 | 32}` | `f${32 | 64}`> ? number :
+    T extends TypeKindMarker<`${'u' | 'i'}${8 | 16 | 32}` | `f${16 | 32 | 64}`> ? number :
     T extends TypeKindMarker<`${'u' | 'i'}${64}`> ? bigint :
     T extends TypeKindMarker<'bool'> ? boolean :
     T extends TypeKindMarker<'String'> ? string :
@@ -408,8 +408,10 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, config: Binc
             value = getI128(view, offset, littleEndian) as Value<T>
             offset += 16;
             break
-        // case "f16":
-        //     throw new BincodeError('Unimplemented', 'f16 decoding is not implemented yet');
+        case "f16":
+            value = view.getFloat16(offset, littleEndian) as Value<T>
+            offset += 2;
+            break
         case "f32":
             value = view.getFloat32(offset, littleEndian) as Value<T>
             offset += 4;
@@ -706,9 +708,11 @@ export const encode = <T>(type: T, value: Value<T>, buffer: ArrayBuffer, offset:
             offset += 16;
             break
         }
-        // case "f16": {
-        //     throw new BincodeError('Unimplemented', 'f16 encoding is not implemented yet');
-        // }
+        case "f16": {
+            dataView.setFloat16(offset, value as number, isLittleEndian);
+            offset += 2;
+            break
+        }
         case "f32": {
             dataView.setFloat32(offset, value as number, isLittleEndian);
             offset += 4;

--- a/src/index.ts
+++ b/src/index.ts
@@ -741,7 +741,6 @@ export const encode = <T>(type: T, value: Value<T>, buffer: ArrayBuffer, offset:
             offset += 8;
             break
         }
-
         // case "f128": {
         //     throw new BincodeError('Unimplemented', 'f128 encoding is not implemented yet');
         // }

--- a/src/index.ts
+++ b/src/index.ts
@@ -717,7 +717,6 @@ export const encode = <T>(type: T, value: Value<T>, buffer: ArrayBuffer, offset:
             offset += 16;
             break
         }
-
         case "f16": {
             if (isVariantIntEncoding) {
                 const tempBuffer = new ArrayBuffer(2);

--- a/src/index.ts
+++ b/src/index.ts
@@ -444,15 +444,9 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, config: Binc
                     byteLength = Number(view.getBigUint64(offset, littleEndian));
                     offset += 8;
                 }
-                try {
-                    const decoder = new TextDecoder();
-                    value = decoder.decode(new Uint8Array(buffer, offset, Number(byteLength))) as Value<T>
-                    offset += byteLength;
-                } catch (err) {
-                    console.error(err)
-                    debugger;
-                    throw err;
-                }
+                const decoder = new TextDecoder();
+                value = decoder.decode(new Uint8Array(buffer, offset, Number(byteLength))) as Value<T>
+                offset += byteLength;
             }
             break
         case "collection":

--- a/src/index.ts
+++ b/src/index.ts
@@ -406,8 +406,6 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, config: Binc
             value = getI128(view, offset, littleEndian) as Value<T>
             offset += 16;
             break
-        
-        // --- INÍCIO DA CORREÇÃO DE DECODE ---
         case "f16":
             if (isVariantIntEncoding) {
                 const { value: rawU16, offset: newOffset } = decodeVariantInt(offset, view, u16);
@@ -447,8 +445,6 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, config: Binc
                 offset += 8;
             }
             break
-        // --- FIM DA CORREÇÃO DE DECODE ---
-
         case "bool":
             value = (view.getUint8(offset) === 1) as Value<T>
             offset += 1;
@@ -737,8 +733,6 @@ export const encode = <T>(type: T, value: Value<T>, buffer: ArrayBuffer, offset:
             offset += 16;
             break
         }
-
-        // --- INÍCIO DA CORREÇÃO DE ENCODE ---
         case "f16": {
             if (isVariantIntEncoding) {
                 const tempBuffer = new ArrayBuffer(2);
@@ -778,8 +772,6 @@ export const encode = <T>(type: T, value: Value<T>, buffer: ArrayBuffer, offset:
             }
             break
         }
-        // --- FIM DA CORREÇÃO DE ENCODE ---
-
         // case "f128": {
         //     throw new BincodeError('Unimplemented', 'f128 encoding is not implemented yet');
         // }

--- a/src/index.ts
+++ b/src/index.ts
@@ -410,7 +410,7 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, len = buffer
         case "f16":
             if (isVariantIntEncoding) {
                 const { value: rawU16, offset: newOffset } = decodeVariantInt(offset, view, u16);
-                offset = newOffset;
+                offset += newOffset;
                 const tempBuffer = new ArrayBuffer(2);
                 const tempView = new DataView(tempBuffer);
                 tempView.setUint16(0, Number(rawU16), littleEndian);
@@ -438,7 +438,7 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, len = buffer
                 let byteLength: number
                 if (isVariantIntEncoding) {
                     const { value, offset: newOffset } = decodeVariantInt(offset, view, u64);
-                    offset = newOffset;
+                    offset += newOffset;
                     byteLength = Number(value);
                 } else {
                     byteLength = Number(view.getBigUint64(offset, littleEndian));
@@ -454,7 +454,7 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, len = buffer
                 let byteLength: number;
                 if (isVariantIntEncoding) {
                     const { value, offset: newOffset } = decodeVariantInt(offset, view, u64);
-                    offset = newOffset;
+                    offset += newOffset;
                     byteLength = Number(value);
                 } else {
                     byteLength = Number(view.getBigUint64(offset, littleEndian));
@@ -467,7 +467,7 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, len = buffer
                         value: element,
                         offset: elementOffset
                     } = decode<unknown>(elementDefinition, buffer, offset, len, config);
-                    offset = elementOffset
+                    offset += elementOffset
                     collection.push(element)
                 }
                 value = collection as Value<T>
@@ -482,7 +482,7 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, len = buffer
                         value: element,
                         offset: elementOffset
                     } = decode<unknown>(elementDefinition, buffer, offset, len, config);
-                    offset = elementOffset
+                    offset += elementOffset
                     tupleValue.push(element)
                 }
                 value = tupleValue as Value<T>
@@ -498,7 +498,7 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, len = buffer
                         value: element,
                         offset: elementOffset
                     } = decode<unknown>(elementDefinition, buffer, offset, len, config);
-                    offset = elementOffset
+                    offset += elementOffset
                     tupleValue.push(element)
                 }
                 value = tupleValue as Value<T>
@@ -516,7 +516,7 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, len = buffer
                             offset: fieldOffset
                         } = decode<unknown>(type, buffer, offset, len, config);
                         decodedObject[field] = fieldValue;
-                        offset = fieldOffset;
+                        offset += fieldOffset;
                     }
                 }
                 value = decodedObject as Value<T>
@@ -543,7 +543,7 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, len = buffer
                 let variantIndex
                 if (isVariantIntEncoding) {
                     let result = decodeVariantInt(offset, view, u32)
-                    offset = result.offset;
+                    offset += result.offset;
                     variantIndex = Number(result.value);
                 } else {
                     variantIndex = view.getUint32(offset, littleEndian);
@@ -555,7 +555,7 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, len = buffer
                 const [variantType, variant] = indexedDefinition[variantIndex];
                 if (variantType !== null) {
                     const { value: variantValue, offset: variantOffset } = decode<unknown>(variantType, buffer, offset, len, config);
-                    offset = variantOffset;
+                    offset += variantOffset;
                     value = EnumVariantValue(variant, variantValue) as Value<T>
                 } else {
                     value = EnumVariantValue(variant) as Value<T>
@@ -586,7 +586,7 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, len = buffer
                 const customType = type as CustomType<unknown, string>;
                 const { value: customValue, offset: customOffset } = customType.decode(buffer, offset, len, config);
                 value = customValue as Value<T>;
-                offset = customOffset;
+                offset += customOffset;
             }
             break
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -312,7 +312,7 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, len = buffer
     if (config.limit !== undefined && offset >= config.limit) {
         throw new BincodeError('OverflowLimit', `Buffer overflow at offset ${offset}, limit is ${config.limit}`);
     }
-    let view = new DataView(buffer, offset, len);
+    let view = new DataView(buffer, offset, len - offset);
     const littleEndian = config.endian === 'little';
     const isVariantIntEncoding = config.intEncoding === 'variant';
     function decodeVariantInt(offset: number, view: DataView, type: IntType): {

--- a/src/index.ts
+++ b/src/index.ts
@@ -358,10 +358,12 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, len = buffer
         throw new BincodeError('InvalidType', `Expected a valid type definition, but got ${type}`);
     }
     if (isVariantIntEncoding && isInt(type) && type[TYPE_KIND] !== 'u8' && type[TYPE_KIND] !== 'i8') {
-        return decodeVariantInt(view, type) as {
+        const result = decodeVariantInt(view, type) as {
             value: Value<T>
             offset: number
-        }
+        };
+        result.offset += offset;
+        return result;
     }
     switch (type[TYPE_KIND]) {
         case "never":

--- a/src/index.ts
+++ b/src/index.ts
@@ -566,7 +566,14 @@ export const decode = <T>(type: T, buffer: ArrayBuffer, offset = 0, len = buffer
         case "option":
             {
                 const optionDefinition = type as OptionType;
-                const variantFlag = view.getUint8(offset);
+                // `view` is constructed at byteOffset=offset (see top of decode),
+                // so view-relative index 0 corresponds to buffer position `offset`.
+                // Passing `offset` here would read at `offset + offset`, which is
+                // either out-of-bounds or the wrong byte whenever this case is
+                // reached at non-zero offset (struct field, collection element,
+                // any nested context). Top-level Option tests didn't catch it
+                // because they always start at offset=0.
+                const variantFlag = view.getUint8(0);
                 offset += 1;
                 if (variantFlag === 0) {
                     return {

--- a/tests/enum.test.ts
+++ b/tests/enum.test.ts
@@ -1,6 +1,6 @@
 import {
     u8, u32, String,
-    Tuple, Enum, Option, Result,
+    Tuple, Enum, Option, Result, Struct, Collection,
     encode, decode, _, $,
     Value,
 } from '../src/index';
@@ -52,6 +52,70 @@ describe('Enum Tests', () => {
         const noneSize = encode(NumberOption, null, buffer);
         const decodedNone = decode(NumberOption, buffer.slice(0, noneSize));
         expect(decodedNone.value).toEqual(null);
+    });
+
+    // Regression: the option decode case used to read the discriminant byte at
+    // `view.getUint8(offset)` instead of `view.getUint8(0)`. Since the view is
+    // already created at byteOffset=offset (see decode setup), passing `offset`
+    // again read at buffer position `offset + offset` — out of bounds for any
+    // option nested deep enough that the residual view shorter than the offset.
+    // Top-level Option tests above use offset=0 so the bug was invisible.
+    test('Option as a struct field (non-zero offset)', () => {
+        const WithOpt = Struct({
+            pad_a: u32,
+            pad_b: u32,
+            opt: Option(u8),
+        });
+        const buffer = new ArrayBuffer(32);
+        const value: Value<typeof WithOpt> = { pad_a: 100, pad_b: 200, opt: 99 };
+        const size = encode(WithOpt, value, buffer);
+        const decoded = decode(WithOpt, buffer.slice(0, size));
+        expect(decoded.value).toEqual(value);
+    });
+
+    test('Option as a struct field — None at non-zero offset', () => {
+        const WithOpt = Struct({
+            pad: u32,
+            opt: Option(u32),
+        });
+        const buffer = new ArrayBuffer(32);
+        const value: Value<typeof WithOpt> = { pad: 50, opt: null };
+        const size = encode(WithOpt, value, buffer);
+        const decoded = decode(WithOpt, buffer.slice(0, size));
+        expect(decoded.value).toEqual(value);
+    });
+
+    test('Option as collection element (non-zero offset on every element after first)', () => {
+        const OptList = Collection(Option(u32));
+        const buffer = new ArrayBuffer(64);
+        const value: Value<typeof OptList> = [10, null, 20, null, 30];
+        const size = encode(OptList, value, buffer);
+        const decoded = decode(OptList, buffer.slice(0, size));
+        expect(decoded.value).toEqual(value);
+    });
+
+    test('Option of nested struct as struct field', () => {
+        // `Value<typeof Outer>` triggers TS2589 (conditional-type recursion
+        // depth) on nested `Option<Struct>`. The roundtrip helper takes
+        // `unknown` to bypass the inference path while still exercising the
+        // encode/decode at runtime, which is the point of this regression.
+        const roundtrip = <T>(t: T, v: unknown, buf: ArrayBuffer): unknown => {
+            const size = encode(t, v as Parameters<typeof encode<T>>[1], buf);
+            return decode(t, buf.slice(0, size)).value;
+        };
+
+        const Inner = Struct({ a: u32, b: u32 });
+        const Outer = Struct({
+            pad: u32,
+            inner: Option(Inner),
+        });
+        const buffer = new ArrayBuffer(64);
+
+        const someValue = { pad: 1, inner: { a: 10, b: 20 } };
+        const noneValue = { pad: 1, inner: null };
+
+        expect(roundtrip(Outer, someValue, buffer)).toEqual(someValue);
+        expect(roundtrip(Outer, noneValue, buffer)).toEqual(noneValue);
     });
 
     test('Result type - Ok variant', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
-    "lib": ["ES2022", "DOM"],
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM"],
     "module": "ESNext",
     "moduleResolution": "node",
     "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["ES2020", "DOM"],
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
     "module": "ESNext",
     "moduleResolution": "node",
     "declaration": true,


### PR DESCRIPTION
Here's what's happening:

f16 is treated as u16: The serde_bincode library (in the Rust backend) doesn't natively support half::f16. When you use SerdeAtomicF16, serde simply takes the raw bits of f16 and treats them as a u16.

varint is applied to u16: Because the Bincode (Rust) configuration is using variable integer encoding, it sees this u16 and applies varint logic to it.

This is why structures (that use f16) will fail: the f16 was sent as 3 bytes ([251, byte1, byte2]), but bincode-ts expected 2 bytes, which in this case was currently commented out.